### PR TITLE
fixed login response structure

### DIFF
--- a/src/agent/structures/responses.ts
+++ b/src/agent/structures/responses.ts
@@ -59,7 +59,7 @@ export interface UploadFileResponse {
 export interface LoginResponse {
   license: License;
   my_profile: MyProfile;
-  chats_summary: ChatsSummary;
+  chats_summary: ChatsSummary[];
 }
 
 export interface SetRoutingStatusResponse {


### PR DESCRIPTION
The actual login response has an array of `ChatsSummary` elements (instead of a single element):

<img width="482" alt="Screen Shot 2023-05-10 at 13 03 45" src="https://github.com/livechat/lc-sdk-js/assets/5114422/d3ea0398-017a-498d-a6fe-2a5c52766006">
