### PR TITLE
LC-132 add remote logout

### DIFF
--- a/src/agent/rtm.ts
+++ b/src/agent/rtm.ts
@@ -79,9 +79,10 @@ export default class RTM extends RTMAPI {
 
   /**
    * Logs the Agent out.
+   * @param agent_id - specifies agent to be logged out. If empty, logs out the current agent.
    */
-  async logout(): Promise<EmptyResponse> {
-    return this.send("logout", {});
+  async logout(agent_id?: string): Promise<EmptyResponse> {
+    return this.send("logout", { agent_id });
   }
 
   /**

--- a/src/agent/web.ts
+++ b/src/agent/web.ts
@@ -431,4 +431,12 @@ export default class Web extends WebAPI {
   async listRoutingStatuses(group_ids?: number[]): Promise<SetRoutingStatusResponse[]> {
     return this.send("list_routing_statuses", { filters: { group_ids } });
   }
+
+   /**
+   * Logs the Agent out.
+   * @param agent_id - specifies agent to be logged out.
+   */
+   async logout(agent_id: string): Promise<EmptyResponse> {
+    return this.send("logout", { agent_id });
+  }
 }

--- a/src/agent/web.ts
+++ b/src/agent/web.ts
@@ -432,11 +432,11 @@ export default class Web extends WebAPI {
     return this.send("list_routing_statuses", { filters: { group_ids } });
   }
 
-   /**
+  /**
    * Logs the Agent out.
    * @param agent_id - specifies agent to be logged out.
    */
-   async logout(agent_id: string): Promise<EmptyResponse> {
+  async logout(agent_id: string): Promise<EmptyResponse> {
     return this.send("logout", { agent_id });
   }
 }


### PR DESCRIPTION
`agent_id` is optional in the RTM method, mandatory in HTTP.